### PR TITLE
Add wallet demo with send/receive pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 ## Stable Coin Price Widget
+
+This example now includes a simple demo wallet flow. Users can sign up or log in and a mock wallet address is generated and stored in local storage. Basic pages allow receiving funds via a QR code, sending mock transactions and viewing history. All wallet state is managed through `WalletProvider`.
+
+**Development**
+
+Dependencies now include `react-router-dom` and `qrcode.react`. Run `npm install` before building.
+
+```bash
+npm install
+npm run dev
+```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1",
+    "qrcode.react": "^1.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,60 @@
-import { useState } from "react";
-import "./App.css";
+import React, { useState } from "react";
+import { Route, Routes, Link, Navigate } from "react-router-dom";
 import StablecoinPriceWidget from "./StableCoinPriceWidget";
+import Login from "./pages/Login";
+import Signup from "./pages/Signup";
+import Dashboard from "./pages/Dashboard";
+import Receive from "./pages/Receive";
+import Send from "./pages/Send";
+import History from "./pages/History";
+import { useWallet } from "./wallet/WalletProvider";
+import "./App.css";
 
 function App() {
   const [darkMode, setDarkMode] = useState(false);
+  const { user } = useWallet();
 
   return (
-    <>
-      <div
-        className={
-          darkMode
-            ? "dark bg-gray-900 min-h-screen"
-            : "bg-gray-100 min-h-screen"
-        }
-      >
+    <div
+      className={
+        darkMode ? "dark bg-gray-900 min-h-screen" : "bg-gray-100 min-h-screen"
+      }
+    >
+      <div className="p-4 flex justify-between">
         <button
           onClick={() => setDarkMode(!darkMode)}
-          className={`m-4 p-2 rounded ${
-            darkMode ? "bg-gray-700 text-white" : "bg-blue-500 text-green"
+          className={`p-2 rounded ${
+            darkMode ? "bg-gray-700 text-white" : "bg-blue-500 text-white"
           }`}
         >
-          Toggle {darkMode ? "Light" : "Dark"} Mode
+          {darkMode ? "Light" : "Dark"} Mode
         </button>
-        <div className="p-6">
-          <StablecoinPriceWidget />
-        </div>
+        <Link to="/" className="underline">
+          Home
+        </Link>
       </div>
-    </>
+      <Routes>
+        <Route path="/" element={<StablecoinPriceWidget />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route
+          path="/dashboard"
+          element={user ? <Dashboard /> : <Navigate to="/login" />}
+        />
+        <Route
+          path="/receive"
+          element={user ? <Receive /> : <Navigate to="/login" />}
+        />
+        <Route
+          path="/send"
+          element={user ? <Send /> : <Navigate to="/login" />}
+        />
+        <Route
+          path="/history"
+          element={user ? <History /> : <Navigate to="/login" />}
+        />
+      </Routes>
+    </div>
   );
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
+import { WalletProvider } from "./wallet/WalletProvider";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <WalletProvider>
+        <App />
+      </WalletProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useWallet } from "../wallet/WalletProvider";
+
+const Dashboard: React.FC = () => {
+  const { walletAddress, user, transactions } = useWallet();
+  const balanceUsd = transactions.reduce(
+    (acc, t) => acc + (t.status === "confirmed" ? -t.amountUsd : 0),
+    1000
+  );
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl font-bold mb-4">Welcome {user?.email}</h1>
+      <div className="mb-4">
+        <div className="text-sm text-gray-600">Wallet:</div>
+        <div className="break-all font-mono">{walletAddress}</div>
+      </div>
+      <div className="text-2xl font-semibold mb-4">Balance: ${balanceUsd.toFixed(2)}</div>
+      <div className="flex gap-2 mb-4">
+        <Link className="flex-1 bg-blue-500 text-white p-2 rounded text-center" to="/receive">Receive</Link>
+        <Link className="flex-1 bg-green-500 text-white p-2 rounded text-center" to="/send">Send</Link>
+      </div>
+      <Link className="underline text-blue-600" to="/history">
+        Transaction History
+      </Link>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useWallet } from "../wallet/WalletProvider";
+
+const History: React.FC = () => {
+  const { transactions } = useWallet();
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Transaction History</h1>
+      <ul className="divide-y divide-gray-200">
+        {transactions.map((tx) => (
+          <li key={tx.id} className="py-2">
+            <div className="text-sm text-gray-600">{new Date(tx.date).toLocaleString()}</div>
+            <div className="text-sm break-all">To: {tx.to}</div>
+            <div className="text-sm">Amount: ${tx.amountUsd.toFixed(2)}</div>
+            <div className="text-sm capitalize">Status: {tx.status}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default History;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import { useWallet } from "../wallet/WalletProvider";
+import { useNavigate } from "react-router-dom";
+
+const Login: React.FC = () => {
+  const { login } = useWallet();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    login(email, password);
+    navigate("/dashboard");
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          className="border p-2 rounded"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-2 rounded"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white p-2 rounded" type="submit">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/Receive.tsx
+++ b/src/pages/Receive.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useWallet } from "../wallet/WalletProvider";
+import QRCode from "qrcode.react";
+
+const Receive: React.FC = () => {
+  const { walletAddress } = useWallet();
+  const link = `${window.location.origin}/pay/${walletAddress}`;
+
+  if (!walletAddress) return null;
+
+  return (
+    <div className="p-4 max-w-sm mx-auto text-center">
+      <h1 className="text-2xl font-bold mb-4">Receive Funds</h1>
+      <div className="mb-4 break-all font-mono">{walletAddress}</div>
+      <div className="flex justify-center mb-4">
+        <QRCode value={walletAddress} />
+      </div>
+      <div className="text-sm">Shareable link:</div>
+      <a href={link} className="text-blue-600 underline break-all">
+        {link}
+      </a>
+    </div>
+  );
+};
+
+export default Receive;

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import { useWallet } from "../wallet/WalletProvider";
+import { useNavigate } from "react-router-dom";
+
+const Send: React.FC = () => {
+  const { send } = useWallet();
+  const navigate = useNavigate();
+  const [to, setTo] = useState("");
+  const [amount, setAmount] = useState(0);
+  const [confirm, setConfirm] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!confirm) {
+      setConfirm(true);
+      return;
+    }
+    await send(to, amount);
+    navigate("/dashboard");
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Send Funds</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          className="border p-2 rounded"
+          placeholder="Recipient Address"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+        />
+        <input
+          type="number"
+          className="border p-2 rounded"
+          placeholder="Amount (USD)"
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+        />
+        <button className="bg-green-500 text-white p-2 rounded" type="submit">
+          {confirm ? "Confirm" : "Send"}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Send;

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import { useWallet } from "../wallet/WalletProvider";
+import { useNavigate } from "react-router-dom";
+
+const Signup: React.FC = () => {
+  const { signUp } = useWallet();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    signUp(email, password);
+    navigate("/dashboard");
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          className="border p-2 rounded"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-2 rounded"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white p-2 rounded" type="submit">
+          Create Account
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Signup;

--- a/src/wallet/WalletProvider.tsx
+++ b/src/wallet/WalletProvider.tsx
@@ -1,0 +1,132 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export type User = {
+  email: string;
+};
+
+export type Transaction = {
+  id: string;
+  date: string;
+  to: string;
+  amountUsd: number;
+  status: "pending" | "confirmed" | "failed";
+};
+
+export type WalletContextType = {
+  user: User | null;
+  walletAddress: string | null;
+  transactions: Transaction[];
+  signUp: (email: string, password: string) => void;
+  login: (email: string, password: string) => void;
+  logout: () => void;
+  send: (to: string, amountUsd: number) => Promise<void>;
+  refreshTransactions: () => Promise<void>;
+};
+
+const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+function randomHex(bytes: number): string {
+  const chars = "0123456789abcdef";
+  let hex = "";
+  for (let i = 0; i < bytes * 2; i++) {
+    hex += chars[Math.floor(Math.random() * 16)];
+  }
+  return hex;
+}
+
+function generateAddress(): string {
+  return `0x${randomHex(20)}`;
+}
+
+export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem("user");
+    const storedWallet = localStorage.getItem("walletAddress");
+    const storedTxs = localStorage.getItem("transactions");
+    if (storedUser) setUser(JSON.parse(storedUser));
+    if (storedWallet) setWalletAddress(storedWallet);
+    if (storedTxs) setTransactions(JSON.parse(storedTxs));
+  }, []);
+
+  useEffect(() => {
+    if (user) localStorage.setItem("user", JSON.stringify(user));
+    else localStorage.removeItem("user");
+  }, [user]);
+
+  useEffect(() => {
+    if (walletAddress) localStorage.setItem("walletAddress", walletAddress);
+  }, [walletAddress]);
+
+  useEffect(() => {
+    localStorage.setItem("transactions", JSON.stringify(transactions));
+  }, [transactions]);
+
+  const signUp = (email: string, _password: string) => {
+    const newUser = { email };
+    setUser(newUser);
+    setWalletAddress(generateAddress());
+  };
+
+  const login = (email: string, _password: string) => {
+    const storedUser = localStorage.getItem("user");
+    if (storedUser && JSON.parse(storedUser).email === email) {
+      setUser({ email });
+      const storedWallet = localStorage.getItem("walletAddress");
+      if (storedWallet) setWalletAddress(storedWallet);
+    }
+  };
+
+  const logout = () => {
+    setUser(null);
+  };
+
+  const send = async (to: string, amountUsd: number) => {
+    const tx: Transaction = {
+      id: Math.random().toString(36).slice(2),
+      date: new Date().toISOString(),
+      to,
+      amountUsd,
+      status: "pending",
+    };
+    setTransactions((t) => [...t, tx]);
+    setTimeout(() => {
+      setTransactions((prev) =>
+        prev.map((p) =>
+          p.id === tx.id ? { ...p, status: "confirmed" } : p
+        )
+      );
+    }, 1000);
+  };
+
+  const refreshTransactions = async () => {
+    // Placeholder for fetching from provider like Covalent or Alchemy
+    return Promise.resolve();
+  };
+
+  const value: WalletContextType = {
+    user,
+    walletAddress,
+    transactions,
+    signUp,
+    login,
+    logout,
+    send,
+    refreshTransactions,
+  };
+
+  return (
+    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
+  );
+};
+
+export function useWallet() {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("WalletProvider missing");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- integrate React Router and wrap the app with `WalletProvider`
- create simple signup/login pages
- implement demo wallet provider storing state in localStorage
- add Send/Receive pages with QR codes and transaction history
- document the new workflow in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing React and other type declarations)*